### PR TITLE
refactor: Change timestamps from Date to bigint in database schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### NEVER ACT WITHOUT EXPLICIT USER APPROVAL
 
 **YOU MUST ALWAYS ASK FOR PERMISSION BEFORE:**
+
 - Making architectural decisions or changes
 - Implementing new features or functionality
 - Modifying APIs, interfaces, or data structures
@@ -18,6 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### FINISH DISCUSSIONS BEFORE WRITING CODE
 
 **IMPORTANT**: When the user asks a question or you're in the middle of a discussion, DO NOT jump to writing code. Always:
+
 1. **Complete the discussion first** - Understand the problem fully
 2. **Analyze and explain** - Work through the issue verbally
 3. **Get confirmation** - Ensure the user agrees with the approach
@@ -32,6 +34,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with th
 ### First Steps When Starting a Session
 
 When you begin working on this project, you MUST:
+
 1. **Read this entire CLAUDE.md file** to understand the project structure and conventions
 2. **Check for ongoing tasks in `.todos/` directory** - Look for any in-progress task files
 3. **Read the key documentation files** in this order:
@@ -75,6 +78,7 @@ This guide helps AI assistants work effectively with the Permiso codebase. For p
 ### Greenfield Development Context
 
 **IMPORTANT**: Permiso is a greenfield project with no legacy constraints:
+
 - **No backward compatibility concerns** - No existing deployments or users to migrate
 - **No legacy code patterns** - All code should follow current best practices without compromise
 - **No migration paths needed** - Database schemas, APIs, and data structures can be designed optimally
@@ -87,6 +91,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 ### Documentation & Code Principles
 
 **Documentation Guidelines:**
+
 - Write as if the spec was designed from the beginning, not evolved over time
 - Avoid phrases like "now allows", "changed from", "previously was"
 - Present features and constraints as inherent design decisions
@@ -95,6 +100,7 @@ This means: Focus on clean, optimal implementations without worrying about exist
 - Keep README.md as single source of truth
 
 **Code Principles:**
+
 - **NO BACKWARDS COMPATIBILITY** - Do not write backwards compatibility code
 - **NO CLASSES** - Export functions from modules only, use explicit dependency injection
 - **NO DYNAMIC IMPORTS** - Always use static imports, never `await import()` or `import()`
@@ -184,12 +190,14 @@ npm run test:client:grep -- "fetch user"      # Only client tests
 ### Git Workflow
 
 **CRITICAL GIT SAFETY RULES**:
+
 1. **NEVER use `git push --force` or `git push -f`** - Force pushing destroys history
 2. **ALL git push commands require EXPLICIT user authorization**
 3. **Use revert commits instead of force push** - To undo changes, create revert commits
 4. **If you need to overwrite remote**, explain consequences and get explicit confirmation
 
 **IMPORTANT**: NEVER commit or push changes without explicit user instruction
+
 - Only run `git add`, `git commit`, or `git push` when the user explicitly asks
 - Common explicit instructions include: "commit", "push", "commit and push", "save to git"
 - Always wait for user approval before making any git operations
@@ -197,6 +205,7 @@ npm run test:client:grep -- "fetch user"      # Only client tests
 **NEW BRANCH REQUIREMENT**: ALL changes must be made on a new feature branch, never directly on main.
 
 When the user asks you to commit and push:
+
 1. Run `./scripts/format-all.sh` to format all files with Prettier
 2. Run `./scripts/lint-all.sh` to ensure code passes linting
 3. Follow the git commit guidelines in the main Claude system prompt
@@ -209,6 +218,7 @@ When the user asks you to commit and push:
 ### Security: Never Use npx
 
 **CRITICAL SECURITY REQUIREMENT**: NEVER use `npx` for any commands. This poses grave security risks by executing arbitrary code.
+
 - **ALWAYS use exact dependency versions** in package.json
 - **ALWAYS use local node_modules binaries** (e.g., `prettier`, `mocha`, `http-server`)
 - **NEVER use `npx prettier`** - use `prettier` from local dependencies
@@ -233,6 +243,7 @@ When the user asks you to commit and push:
 - **Type-safe Queries**: All queries use `db.one<XxxDbRow>()` with explicit type parameters
 
 **Query Optimization Guidelines**:
+
 - **Prefer simple separate queries over complex joins** when it only saves 1-3 database calls
 - **Use joins only to prevent N+1 query problems** (e.g., fetching data for many items in a loop)
 - **Prioritize code simplicity and readability** over minor performance optimizations
@@ -407,6 +418,7 @@ Benefits: Keeps analysis artifacts separate from source code, allows iterative w
 ### Build & Lint Workflow
 
 **ALWAYS follow this sequence:**
+
 1. Run `./scripts/lint-all.sh` first
 2. Run `./scripts/build.sh`
 3. **If build fails and you make changes**: You MUST run `./scripts/lint-all.sh` again before building

--- a/database/permiso/migrations/20250823075842_initial_schema.js
+++ b/database/permiso/migrations/20250823075842_initial_schema.js
@@ -6,10 +6,10 @@ export async function up(knex) {
   // Create organization table
   await knex.schema.createTable("organization", (table) => {
     table.string("id", 255).primary();
-    table.string("name", 255).notNullable().defaultTo("");
+    table.string("name", 255).notNullable();
     table.text("description");
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
-    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
+    table.bigint("updated_at").notNullable();
 
     // Indexes
     table.index("created_at");
@@ -21,8 +21,8 @@ export async function up(knex) {
     table.string("parent_id", 255).notNullable();
     table.string("name", 255).notNullable();
     table.jsonb("value").notNullable();
-    table.boolean("hidden").notNullable().defaultTo(false);
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.boolean("hidden").notNullable();
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["parent_id", "name"]);
@@ -44,10 +44,10 @@ export async function up(knex) {
   await knex.schema.createTable("role", (table) => {
     table.string("id", 255).notNullable();
     table.string("org_id", 255).notNullable();
-    table.string("name", 255).notNullable().defaultTo("");
+    table.string("name", 255).notNullable();
     table.text("description");
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
-    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
+    table.bigint("updated_at").notNullable();
 
     // Composite primary key
     table.primary(["id", "org_id"]);
@@ -71,8 +71,8 @@ export async function up(knex) {
     table.string("org_id", 255).notNullable();
     table.string("name", 255).notNullable();
     table.jsonb("value").notNullable();
-    table.boolean("hidden").notNullable().defaultTo(false);
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.boolean("hidden").notNullable();
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["parent_id", "org_id", "name"]);
@@ -96,8 +96,8 @@ export async function up(knex) {
     table.string("org_id", 255).notNullable();
     table.string("identity_provider", 255).notNullable();
     table.string("identity_provider_user_id", 255).notNullable();
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
-    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
+    table.bigint("updated_at").notNullable();
 
     // Composite primary key
     table.primary(["id", "org_id"]);
@@ -121,8 +121,8 @@ export async function up(knex) {
     table.string("org_id", 255).notNullable();
     table.string("name", 255).notNullable();
     table.jsonb("value").notNullable();
-    table.boolean("hidden").notNullable().defaultTo(false);
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.boolean("hidden").notNullable();
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["parent_id", "org_id", "name"]);
@@ -144,10 +144,10 @@ export async function up(knex) {
   await knex.schema.createTable("resource", (table) => {
     table.string("id", 255).notNullable();
     table.string("org_id", 255).notNullable();
-    table.string("name", 255);
+    table.string("name", 255).notNullable();
     table.text("description");
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
-    table.timestamp("updated_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
+    table.bigint("updated_at").notNullable();
 
     // Composite primary key
     table.primary(["id", "org_id"]);
@@ -170,7 +170,7 @@ export async function up(knex) {
     table.string("user_id", 255).notNullable();
     table.string("role_id", 255).notNullable();
     table.string("org_id", 255).notNullable();
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["user_id", "role_id", "org_id"]);
@@ -198,7 +198,7 @@ export async function up(knex) {
     table.string("org_id", 255).notNullable();
     table.string("resource_id", 255).notNullable();
     table.string("action", 255).notNullable();
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["user_id", "org_id", "resource_id", "action"]);
@@ -227,7 +227,7 @@ export async function up(knex) {
     table.string("org_id", 255).notNullable();
     table.string("resource_id", 255).notNullable();
     table.string("action", 255).notNullable();
-    table.timestamp("created_at").notNullable().defaultTo(knex.fn.now());
+    table.bigint("created_at").notNullable();
 
     // Composite primary key
     table.primary(["role_id", "org_id", "resource_id", "action"]);

--- a/node/packages/permiso-client/src/generated/types.ts
+++ b/node/packages/permiso-client/src/generated/types.ts
@@ -25,7 +25,6 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  DateTime: { input: string; output: string };
   JSON: { input: unknown; output: unknown };
 };
 
@@ -60,7 +59,7 @@ export type CreateUserInput = {
 export type EffectivePermission = {
   __typename?: "EffectivePermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   resourceId: Scalars["ID"]["output"];
   source: Scalars["String"]["output"];
   sourceId: Maybe<Scalars["ID"]["output"]>;
@@ -227,14 +226,14 @@ export type MutationUpdateUserArgs = {
 
 export type Organization = {
   __typename?: "Organization";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Scalars["String"]["output"];
   properties: Array<Property>;
   resources: ResourceConnection;
   roles: RoleConnection;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
   users: UserConnection;
 };
 
@@ -280,7 +279,7 @@ export type PaginationInput = {
 
 export type Permission = {
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];
@@ -288,7 +287,7 @@ export type Permission = {
 
 export type Property = {
   __typename?: "Property";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   hidden: Scalars["Boolean"]["output"];
   name: Scalars["String"]["output"];
   value: Maybe<Scalars["JSON"]["output"]>;
@@ -434,14 +433,14 @@ export type QueryUsersByIdsArgs = {
 
 export type Resource = {
   __typename?: "Resource";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Maybe<Scalars["String"]["output"]>;
   orgId: Scalars["ID"]["output"];
   organization: Organization;
   permissions: Array<Permission>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
 };
 
 export type ResourceConnection = {
@@ -457,7 +456,7 @@ export type ResourceFilter = {
 
 export type Role = {
   __typename?: "Role";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Scalars["String"]["output"];
@@ -465,7 +464,7 @@ export type Role = {
   organization: Organization;
   permissions: Array<RolePermission>;
   properties: Array<Property>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
   users: Array<User>;
 };
 
@@ -483,7 +482,7 @@ export type RoleFilter = {
 export type RolePermission = Permission & {
   __typename?: "RolePermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];
@@ -515,7 +514,7 @@ export type UpdateUserInput = {
 
 export type User = {
   __typename?: "User";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   effectivePermissions: Array<EffectivePermission>;
   id: Scalars["ID"]["output"];
   identityProvider: Scalars["String"]["output"];
@@ -525,7 +524,7 @@ export type User = {
   permissions: Array<UserPermission>;
   properties: Array<Property>;
   roles: Array<Role>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
 };
 
 export type UserEffectivePermissionsArgs = {
@@ -549,7 +548,7 @@ export type UserFilter = {
 export type UserPermission = Permission & {
   __typename?: "UserPermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];

--- a/node/packages/permiso-integration-tests/src/tests/organizations.test.ts
+++ b/node/packages/permiso-integration-tests/src/tests/organizations.test.ts
@@ -167,8 +167,8 @@ describe("Organizations", () => {
         value: "premium",
         hidden: false,
       });
-      expect(result.data?.organization?.createdAt).to.be.a("string");
-      expect(result.data?.organization?.updatedAt).to.be.a("string");
+      expect(result.data?.organization?.createdAt).to.be.a("number");
+      expect(result.data?.organization?.updatedAt).to.be.a("number");
     });
 
     it("should return null for non-existent organization", async () => {

--- a/node/packages/permiso-integration-tests/src/tests/property-operations.test.ts
+++ b/node/packages/permiso-integration-tests/src/tests/property-operations.test.ts
@@ -82,7 +82,7 @@ describe("Property Operations", () => {
           "initial_value",
         );
         expect(result.data?.organizationProperty?.hidden).to.be.false;
-        expect(result.data?.organizationProperty?.createdAt).to.be.a("string");
+        expect(result.data?.organizationProperty?.createdAt).to.be.a("number");
       });
 
       it("should return null for non-existent property", async () => {

--- a/node/packages/permiso-server/src/domain/organization/create-organization.ts
+++ b/node/packages/permiso-server/src/domain/organization/create-organization.ts
@@ -18,10 +18,13 @@ export async function createOrganization(
     const rootDb = ctx.db.upgradeToRoot?.("Create new organization") || ctx.db;
 
     const org = await rootDb.tx(async (t) => {
+      const now = Date.now();
       const params = {
         id: input.id,
         name: input.name,
         description: input.description !== undefined ? input.description : null,
+        created_at: now,
+        updated_at: now,
       };
 
       const orgRow = await t.one<OrganizationDbRow>(
@@ -35,6 +38,7 @@ export async function createOrganization(
           name: p.name,
           value: p.value === undefined ? null : JSON.stringify(p.value),
           hidden: p.hidden ?? false,
+          created_at: now,
         }));
 
         for (const prop of propertyValues) {

--- a/node/packages/permiso-server/src/domain/organization/set-organization-property.ts
+++ b/node/packages/permiso-server/src/domain/organization/set-organization-property.ts
@@ -20,12 +20,13 @@ export async function setOrganizationProperty(
       name,
       value: value === undefined ? null : JSON.stringify(value),
       hidden,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.one<PropertyDbRow>(
       `${sql.insert("organization_property", params)}
-       ON CONFLICT (parent_id, name) 
-       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = NOW()
+       ON CONFLICT (parent_id, name)
+       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = EXCLUDED.created_at
        RETURNING *`,
       params,
     );

--- a/node/packages/permiso-server/src/domain/organization/update-organization.ts
+++ b/node/packages/permiso-server/src/domain/organization/update-organization.ts
@@ -26,8 +26,10 @@ export async function updateOrganization(
       updateParams.description = input.description;
     }
 
+    updateParams.updated_at = Date.now();
+
     const query = `
-      ${sql.update("organization", updateParams)}, updated_at = NOW()
+      ${sql.update("organization", updateParams)}
       WHERE id = $(id)
       RETURNING *
     `;

--- a/node/packages/permiso-server/src/domain/permission/get-effective-permissions-by-prefix.ts
+++ b/node/packages/permiso-server/src/domain/permission/get-effective-permissions-by-prefix.ts
@@ -55,7 +55,7 @@ export async function getEffectivePermissionsByPrefix(
           resource_id: string;
           action: string;
           source_id: string;
-          created_at: Date;
+          created_at: number;
         }>
       ).map((p) => ({
         resourceId: p.resource_id,
@@ -69,7 +69,7 @@ export async function getEffectivePermissionsByPrefix(
           resource_id: string;
           action: string;
           source_id: string;
-          created_at: Date;
+          created_at: number;
         }>
       ).map((p) => ({
         resourceId: p.resource_id,

--- a/node/packages/permiso-server/src/domain/permission/get-effective-permissions.ts
+++ b/node/packages/permiso-server/src/domain/permission/get-effective-permissions.ts
@@ -45,7 +45,7 @@ export async function getEffectivePermissions(
             resource_id: string;
             action: string;
             source_id: string;
-            created_at: Date;
+            created_at: number;
           }>
         ).map((p) => ({
           resourceId: p.resource_id,
@@ -59,7 +59,7 @@ export async function getEffectivePermissions(
             resource_id: string;
             action: string;
             source_id: string;
-            created_at: Date;
+            created_at: number;
           }>
         ).map((p) => ({
           resourceId: p.resource_id,
@@ -117,7 +117,7 @@ export async function getEffectivePermissions(
           resource_id: string;
           action: string;
           source_id: string;
-          created_at: Date;
+          created_at: number;
         }>
       ).map((p) => ({
         resourceId: p.resource_id,
@@ -131,7 +131,7 @@ export async function getEffectivePermissions(
           resource_id: string;
           action: string;
           source_id: string;
-          created_at: Date;
+          created_at: number;
         }>
       ).map((p) => ({
         resourceId: p.resource_id,

--- a/node/packages/permiso-server/src/domain/permission/get-permissions-by-resource.ts
+++ b/node/packages/permiso-server/src/domain/permission/get-permissions-by-resource.ts
@@ -17,7 +17,7 @@ export async function getPermissionsByResource(
       roleId?: string;
       resourceId: string;
       action: string;
-      createdAt: Date;
+      createdAt: number;
       orgId: string;
     }>
   >

--- a/node/packages/permiso-server/src/domain/permission/grant-role-permission.ts
+++ b/node/packages/permiso-server/src/domain/permission/grant-role-permission.ts
@@ -22,11 +22,12 @@ export async function grantRolePermission(
       role_id: roleId,
       resource_id: resourceId,
       action: action,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.one<RolePermissionDbRow>(
       `${sql.insert("role_permission", params)}
-       ON CONFLICT (org_id, role_id, resource_id, action) DO UPDATE SET created_at = NOW()
+       ON CONFLICT (org_id, role_id, resource_id, action) DO UPDATE SET created_at = $(created_at)
        RETURNING *`,
       params,
     );

--- a/node/packages/permiso-server/src/domain/permission/grant-user-permission.ts
+++ b/node/packages/permiso-server/src/domain/permission/grant-user-permission.ts
@@ -22,11 +22,12 @@ export async function grantUserPermission(
       user_id: userId,
       resource_id: resourceId,
       action: action,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.one<UserPermissionDbRow>(
       `${sql.insert("user_permission", params)}
-       ON CONFLICT (org_id, user_id, resource_id, action) DO UPDATE SET created_at = NOW()
+       ON CONFLICT (org_id, user_id, resource_id, action) DO UPDATE SET created_at = $(created_at)
        RETURNING *`,
       params,
     );

--- a/node/packages/permiso-server/src/domain/resource/create-resource.ts
+++ b/node/packages/permiso-server/src/domain/resource/create-resource.ts
@@ -13,11 +13,14 @@ export async function createResource(
   input: CreateResourceInput,
 ): Promise<Result<Resource>> {
   try {
+    const now = Date.now();
     const params = {
       id: input.id,
       org_id: ctx.orgId,
       name: input.name ?? null,
       description: input.description ?? null,
+      created_at: now,
+      updated_at: now,
     };
 
     const row = await ctx.db.one<ResourceDbRow>(

--- a/node/packages/permiso-server/src/domain/resource/update-resource.ts
+++ b/node/packages/permiso-server/src/domain/resource/update-resource.ts
@@ -24,12 +24,14 @@ export async function updateResource(
       updateParams.description = input.description;
     }
 
+    updateParams.updated_at = Date.now();
+
     const whereParams = {
       resource_id: resourceId,
     };
 
     const query = `
-      ${sql.update("resource", updateParams)}, updated_at = NOW()
+      ${sql.update("resource", updateParams)}
       WHERE id = $(resource_id)
       RETURNING *
     `;

--- a/node/packages/permiso-server/src/domain/role/create-role.ts
+++ b/node/packages/permiso-server/src/domain/role/create-role.ts
@@ -14,11 +14,14 @@ export async function createRole(
 ): Promise<Result<Role>> {
   try {
     const role = await ctx.db.tx(async (t) => {
+      const now = Date.now();
       const params = {
         id: input.id,
         org_id: ctx.orgId,
         name: input.name,
         description: input.description ?? null,
+        created_at: now,
+        updated_at: now,
       };
 
       const roleRow = await t.one<RoleDbRow>(
@@ -33,6 +36,7 @@ export async function createRole(
           name: p.name,
           value: p.value === undefined ? null : JSON.stringify(p.value),
           hidden: p.hidden ?? false,
+          created_at: now,
         }));
 
         for (const prop of propertyValues) {

--- a/node/packages/permiso-server/src/domain/role/set-role-property.ts
+++ b/node/packages/permiso-server/src/domain/role/set-role-property.ts
@@ -21,12 +21,13 @@ export async function setRoleProperty(
       name,
       value: value === undefined ? null : JSON.stringify(value),
       hidden,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.one<PropertyDbRow>(
       `${sql.insert("role_property", params)}
-       ON CONFLICT (org_id, parent_id, name) 
-       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = NOW()
+       ON CONFLICT (org_id, parent_id, name)
+       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = EXCLUDED.created_at
        RETURNING *`,
       params,
     );

--- a/node/packages/permiso-server/src/domain/role/update-role.ts
+++ b/node/packages/permiso-server/src/domain/role/update-role.ts
@@ -24,12 +24,14 @@ export async function updateRole(
       updateParams.description = input.description;
     }
 
+    updateParams.updated_at = Date.now();
+
     const whereParams = {
       role_id: roleId,
     };
 
     const query = `
-      ${sql.update("role", updateParams)}, updated_at = NOW()
+      ${sql.update("role", updateParams)}
       WHERE id = $(role_id)
       RETURNING *
     `;

--- a/node/packages/permiso-server/src/domain/user/assign-user-role.ts
+++ b/node/packages/permiso-server/src/domain/user/assign-user-role.ts
@@ -17,6 +17,7 @@ export async function assignUserRole(
       org_id: ctx.orgId,
       user_id: userId,
       role_id: roleId,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.oneOrNone<UserRoleDbRow>(

--- a/node/packages/permiso-server/src/domain/user/create-user.ts
+++ b/node/packages/permiso-server/src/domain/user/create-user.ts
@@ -14,11 +14,14 @@ export async function createUser(
 ): Promise<Result<User>> {
   try {
     const user = await ctx.db.tx(async (t) => {
+      const now = Date.now();
       const params = {
         id: input.id,
         org_id: ctx.orgId,
         identity_provider: input.identityProvider,
         identity_provider_user_id: input.identityProviderUserId,
+        created_at: now,
+        updated_at: now,
       };
 
       const userRow = await t.one<UserDbRow>(
@@ -33,6 +36,7 @@ export async function createUser(
           name: p.name,
           value: p.value === undefined ? null : JSON.stringify(p.value),
           hidden: p.hidden ?? false,
+          created_at: now,
         }));
 
         for (const prop of propertyValues) {
@@ -46,6 +50,7 @@ export async function createUser(
             user_id: input.id,
             role_id: roleId,
             org_id: ctx.orgId,
+            created_at: now,
           };
           await t.none(sql.insert("user_role", roleParams), roleParams);
         }

--- a/node/packages/permiso-server/src/domain/user/set-user-property.ts
+++ b/node/packages/permiso-server/src/domain/user/set-user-property.ts
@@ -21,12 +21,13 @@ export async function setUserProperty(
       name,
       value: value === undefined ? null : JSON.stringify(value),
       hidden,
+      created_at: Date.now(),
     };
 
     const row = await ctx.db.one<PropertyDbRow>(
       `${sql.insert("user_property", params)}
-       ON CONFLICT (org_id, parent_id, name) 
-       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = NOW()
+       ON CONFLICT (org_id, parent_id, name)
+       DO UPDATE SET value = EXCLUDED.value, hidden = EXCLUDED.hidden, created_at = EXCLUDED.created_at
        RETURNING *`,
       params,
     );

--- a/node/packages/permiso-server/src/domain/user/update-user.ts
+++ b/node/packages/permiso-server/src/domain/user/update-user.ts
@@ -25,12 +25,13 @@ export async function updateUser(
     }
 
     const snakeParams = typeUtils.toSnakeCase(updateParams);
+    snakeParams.updated_at = Date.now();
     const whereParams = {
       user_id: userId,
     };
 
     const query = `
-      ${sql.update('"user"', snakeParams)}, updated_at = NOW()
+      ${sql.update('"user"', snakeParams)}
       WHERE id = $(user_id)
       RETURNING *
     `;

--- a/node/packages/permiso-server/src/generated/graphql.ts
+++ b/node/packages/permiso-server/src/generated/graphql.ts
@@ -35,7 +35,6 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  DateTime: { input: Date; output: Date };
   JSON: { input: unknown; output: unknown };
 };
 
@@ -70,7 +69,7 @@ export type CreateUserInput = {
 export type EffectivePermission = {
   __typename?: "EffectivePermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   resourceId: Scalars["ID"]["output"];
   source: Scalars["String"]["output"];
   sourceId: Maybe<Scalars["ID"]["output"]>;
@@ -237,14 +236,14 @@ export type MutationUpdateUserArgs = {
 
 export type Organization = {
   __typename?: "Organization";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Scalars["String"]["output"];
   properties: Array<Property>;
   resources: ResourceConnection;
   roles: RoleConnection;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
   users: UserConnection;
 };
 
@@ -290,7 +289,7 @@ export type PaginationInput = {
 
 export type Permission = {
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];
@@ -298,7 +297,7 @@ export type Permission = {
 
 export type Property = {
   __typename?: "Property";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   hidden: Scalars["Boolean"]["output"];
   name: Scalars["String"]["output"];
   value: Maybe<Scalars["JSON"]["output"]>;
@@ -444,14 +443,14 @@ export type QueryUsersByIdsArgs = {
 
 export type Resource = {
   __typename?: "Resource";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Maybe<Scalars["String"]["output"]>;
   orgId: Scalars["ID"]["output"];
   organization: Organization;
   permissions: Array<Permission>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
 };
 
 export type ResourceConnection = {
@@ -467,7 +466,7 @@ export type ResourceFilter = {
 
 export type Role = {
   __typename?: "Role";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   description: Maybe<Scalars["String"]["output"]>;
   id: Scalars["ID"]["output"];
   name: Scalars["String"]["output"];
@@ -475,7 +474,7 @@ export type Role = {
   organization: Organization;
   permissions: Array<RolePermission>;
   properties: Array<Property>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
   users: Array<User>;
 };
 
@@ -493,7 +492,7 @@ export type RoleFilter = {
 export type RolePermission = Permission & {
   __typename?: "RolePermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];
@@ -525,7 +524,7 @@ export type UpdateUserInput = {
 
 export type User = {
   __typename?: "User";
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   effectivePermissions: Array<EffectivePermission>;
   id: Scalars["ID"]["output"];
   identityProvider: Scalars["String"]["output"];
@@ -535,7 +534,7 @@ export type User = {
   permissions: Array<UserPermission>;
   properties: Array<Property>;
   roles: Array<Role>;
-  updatedAt: Scalars["DateTime"]["output"];
+  updatedAt: Scalars["Float"]["output"];
 };
 
 export type UserEffectivePermissionsArgs = {
@@ -559,7 +558,7 @@ export type UserFilter = {
 export type UserPermission = Permission & {
   __typename?: "UserPermission";
   action: Scalars["String"]["output"];
-  createdAt: Scalars["DateTime"]["output"];
+  createdAt: Scalars["Float"]["output"];
   organization: Organization;
   resource: Resource;
   resourceId: Scalars["ID"]["output"];
@@ -690,8 +689,8 @@ export type ResolversTypes = ResolversObject<{
   CreateResourceInput: CreateResourceInput;
   CreateRoleInput: CreateRoleInput;
   CreateUserInput: CreateUserInput;
-  DateTime: ResolverTypeWrapper<Scalars["DateTime"]["output"]>;
   EffectivePermission: ResolverTypeWrapper<EffectivePermission>;
+  Float: ResolverTypeWrapper<Scalars["Float"]["output"]>;
   GrantRolePermissionInput: GrantRolePermissionInput;
   GrantUserPermissionInput: GrantUserPermissionInput;
   ID: ResolverTypeWrapper<Scalars["ID"]["output"]>;
@@ -752,8 +751,8 @@ export type ResolversParentTypes = ResolversObject<{
   CreateResourceInput: CreateResourceInput;
   CreateRoleInput: CreateRoleInput;
   CreateUserInput: CreateUserInput;
-  DateTime: Scalars["DateTime"]["output"];
   EffectivePermission: EffectivePermission;
+  Float: Scalars["Float"]["output"];
   GrantRolePermissionInput: GrantRolePermissionInput;
   GrantUserPermissionInput: GrantUserPermissionInput;
   ID: Scalars["ID"]["output"];
@@ -798,18 +797,13 @@ export type ResolversParentTypes = ResolversObject<{
   };
 }>;
 
-export interface DateTimeScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes["DateTime"], any> {
-  name: "DateTime";
-}
-
 export type EffectivePermissionResolvers<
   ContextType = GraphQLContext,
   ParentType extends
     ResolversParentTypes["EffectivePermission"] = ResolversParentTypes["EffectivePermission"],
 > = ResolversObject<{
   action?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   resourceId?: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
   source?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   sourceId?: Resolver<Maybe<ResolversTypes["ID"]>, ParentType, ContextType>;
@@ -983,7 +977,7 @@ export type OrganizationResolvers<
   ParentType extends
     ResolversParentTypes["Organization"] = ResolversParentTypes["Organization"],
 > = ResolversObject<{
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   description?: Resolver<
     Maybe<ResolversTypes["String"]>,
     ParentType,
@@ -1008,7 +1002,7 @@ export type OrganizationResolvers<
     ContextType,
     Partial<OrganizationRolesArgs>
   >;
-  updatedAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   users?: Resolver<
     ResolversTypes["UserConnection"],
     ParentType,
@@ -1068,7 +1062,7 @@ export type PermissionResolvers<
     ContextType
   >;
   action?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   organization?: Resolver<
     ResolversTypes["Organization"],
     ParentType,
@@ -1083,7 +1077,7 @@ export type PropertyResolvers<
   ParentType extends
     ResolversParentTypes["Property"] = ResolversParentTypes["Property"],
 > = ResolversObject<{
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   hidden?: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   name?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   value?: Resolver<Maybe<ResolversTypes["JSON"]>, ParentType, ContextType>;
@@ -1234,7 +1228,7 @@ export type ResourceResolvers<
   ParentType extends
     ResolversParentTypes["Resource"] = ResolversParentTypes["Resource"],
 > = ResolversObject<{
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   description?: Resolver<
     Maybe<ResolversTypes["String"]>,
     ParentType,
@@ -1253,7 +1247,7 @@ export type ResourceResolvers<
     ParentType,
     ContextType
   >;
-  updatedAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1273,7 +1267,7 @@ export type RoleResolvers<
   ParentType extends
     ResolversParentTypes["Role"] = ResolversParentTypes["Role"],
 > = ResolversObject<{
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   description?: Resolver<
     Maybe<ResolversTypes["String"]>,
     ParentType,
@@ -1297,7 +1291,7 @@ export type RoleResolvers<
     ParentType,
     ContextType
   >;
-  updatedAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   users?: Resolver<Array<ResolversTypes["User"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
@@ -1319,7 +1313,7 @@ export type RolePermissionResolvers<
     ResolversParentTypes["RolePermission"] = ResolversParentTypes["RolePermission"],
 > = ResolversObject<{
   action?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   organization?: Resolver<
     ResolversTypes["Organization"],
     ParentType,
@@ -1337,7 +1331,7 @@ export type UserResolvers<
   ParentType extends
     ResolversParentTypes["User"] = ResolversParentTypes["User"],
 > = ResolversObject<{
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   effectivePermissions?: Resolver<
     Array<ResolversTypes["EffectivePermission"]>,
     ParentType,
@@ -1372,7 +1366,7 @@ export type UserResolvers<
     ContextType
   >;
   roles?: Resolver<Array<ResolversTypes["Role"]>, ParentType, ContextType>;
-  updatedAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  updatedAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1393,7 +1387,7 @@ export type UserPermissionResolvers<
     ResolversParentTypes["UserPermission"] = ResolversParentTypes["UserPermission"],
 > = ResolversObject<{
   action?: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  createdAt?: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  createdAt?: Resolver<ResolversTypes["Float"], ParentType, ContextType>;
   organization?: Resolver<
     ResolversTypes["Organization"],
     ParentType,
@@ -1407,7 +1401,6 @@ export type UserPermissionResolvers<
 }>;
 
 export type Resolvers<ContextType = GraphQLContext> = ResolversObject<{
-  DateTime?: GraphQLScalarType;
   EffectivePermission?: EffectivePermissionResolvers<ContextType>;
   JSON?: GraphQLScalarType;
   Mutation?: MutationResolvers<ContextType>;

--- a/node/packages/permiso-server/src/schema.graphql
+++ b/node/packages/permiso-server/src/schema.graphql
@@ -1,4 +1,3 @@
-scalar DateTime
 scalar JSON
 
 # Core Types
@@ -7,8 +6,8 @@ type Organization {
   name: String!
   description: String
   properties: [Property!]!
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: Float!
+  updatedAt: Float!
   
   # Relationships
   users(filter: UserFilter, pagination: PaginationInput): UserConnection!
@@ -22,8 +21,8 @@ type User {
   identityProvider: String!
   identityProviderUserId: String!
   properties: [Property!]!
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: Float!
+  updatedAt: Float!
   
   # Relationships
   organization: Organization!
@@ -38,8 +37,8 @@ type Role {
   name: String!
   description: String
   properties: [Property!]!
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: Float!
+  updatedAt: Float!
   
   # Relationships
   organization: Organization!
@@ -52,8 +51,8 @@ type Resource {
   orgId: ID!
   name: String
   description: String
-  createdAt: DateTime!
-  updatedAt: DateTime!
+  createdAt: Float!
+  updatedAt: Float!
   
   # Relationships
   organization: Organization!
@@ -64,13 +63,13 @@ type Property {
   name: String!
   value: JSON
   hidden: Boolean!
-  createdAt: DateTime!
+  createdAt: Float!
 }
 
 interface Permission {
   resourceId: ID!
   action: String!
-  createdAt: DateTime!
+  createdAt: Float!
   organization: Organization!
   resource: Resource!
 }
@@ -79,7 +78,7 @@ type UserPermission implements Permission {
   userId: ID!
   resourceId: ID!
   action: String!
-  createdAt: DateTime!
+  createdAt: Float!
   organization: Organization!
   resource: Resource!
   user: User!
@@ -89,7 +88,7 @@ type RolePermission implements Permission {
   roleId: ID!
   resourceId: ID!
   action: String!
-  createdAt: DateTime!
+  createdAt: Float!
   organization: Organization!
   resource: Resource!
   role: Role!
@@ -100,7 +99,7 @@ type EffectivePermission {
   action: String!
   source: String! # 'user' or 'role'
   sourceId: ID # userId or roleId
-  createdAt: DateTime!
+  createdAt: Float!
 }
 
 # Connection types for pagination

--- a/node/packages/permiso-server/src/types.ts
+++ b/node/packages/permiso-server/src/types.ts
@@ -7,7 +7,7 @@ export type UserPermissionWithOrgId = {
   orgId: string;
   resourceId: string;
   action: string;
-  createdAt: Date;
+  createdAt: number;
 };
 
 export type RolePermissionWithOrgId = {
@@ -15,7 +15,7 @@ export type RolePermissionWithOrgId = {
   orgId: string;
   resourceId: string;
   action: string;
-  createdAt: Date;
+  createdAt: number;
 };
 
 // Database row types (snake_case)
@@ -23,8 +23,8 @@ export type OrganizationDbRow = {
   id: string;
   name: string;
   description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
 };
 
 export type PropertyDbRow = {
@@ -33,7 +33,7 @@ export type PropertyDbRow = {
   name: string;
   value: unknown; // JSONB value
   hidden: boolean;
-  created_at: Date;
+  created_at: number;
 };
 
 // Legacy type aliases for backward compatibility during migration
@@ -46,8 +46,8 @@ export type RoleDbRow = {
   org_id: string;
   name: string;
   description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
 };
 
 export type UserDbRow = {
@@ -55,8 +55,8 @@ export type UserDbRow = {
   org_id: string;
   identity_provider: string;
   identity_provider_user_id: string;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
 };
 
 export type ResourceDbRow = {
@@ -64,15 +64,15 @@ export type ResourceDbRow = {
   org_id: string;
   name: string | null;
   description: string | null;
-  created_at: Date;
-  updated_at: Date;
+  created_at: number;
+  updated_at: number;
 };
 
 export type UserRoleDbRow = {
   user_id: string;
   role_id: string;
   org_id: string;
-  created_at: Date;
+  created_at: number;
 };
 
 export type UserPermissionDbRow = {
@@ -80,7 +80,7 @@ export type UserPermissionDbRow = {
   org_id: string;
   resource_id: string;
   action: string;
-  created_at: Date;
+  created_at: number;
 };
 
 export type RolePermissionDbRow = {
@@ -88,7 +88,7 @@ export type RolePermissionDbRow = {
   org_id: string;
   resource_id: string;
   action: string;
-  created_at: Date;
+  created_at: number;
 };
 
 // Domain-specific types that bridge database and GraphQL
@@ -98,7 +98,7 @@ export type UserRole = {
   userId: string;
   roleId: string;
   orgId: string;
-  createdAt: Date;
+  createdAt: number;
 };
 
 // Extended types with properties as Record (for internal use)
@@ -106,8 +106,8 @@ export type OrganizationWithProperties = {
   id: string;
   name: string;
   description?: string | null;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: number;
+  updatedAt: number;
   properties: Record<string, unknown>;
 };
 
@@ -116,8 +116,8 @@ export type RoleWithProperties = {
   orgId: string;
   name: string;
   description?: string | null;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: number;
+  updatedAt: number;
   properties: Record<string, unknown>;
 };
 
@@ -126,8 +126,8 @@ export type UserWithProperties = {
   orgId: string;
   identityProvider: string;
   identityProviderUserId: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: number;
+  updatedAt: number;
   properties: Record<string, unknown>;
   roleIds: string[];
 };


### PR DESCRIPTION
- Remove all default values from database schema - values must now be explicitly provided from client code
- Change all timestamp columns from timestamp to bigint type for epoch millisecond storage
- Update TypeScript types to use number instead of Date for all timestamp fields
- Modify GraphQL schema to use Float instead of DateTime for timestamp fields
- Update all domain code to use Date.now() for generating timestamps
- Fix test expectations to expect numbers instead of strings for timestamps

This is a breaking change that requires all timestamps to be provided as epoch milliseconds from the client code. No backward compatibility is maintained as this is a greenfield project.

🤖 Generated with [Claude Code](https://claude.ai/code)