### PR TITLE
feat: Add pg-promise type parser for bigint to number conversion

### DIFF
--- a/node/packages/permiso-db/src/index.ts
+++ b/node/packages/permiso-db/src/index.ts
@@ -4,6 +4,9 @@ export * as sql from "./sql.js";
 export { createLazyDb } from "./lazy-db.js";
 
 const pgp = pgPromise();
+// Parse PostgreSQL bigint (type OID 20) as JavaScript numbers
+// This ensures timestamps stored as bigint are returned as numbers, not strings
+pgp.pg.types.setTypeParser(20, (val: string) => parseInt(val, 10));
 
 // Export the Database interface - this is what all consumers use
 export interface Database {


### PR DESCRIPTION
Parse PostgreSQL bigint values (OID 20) as JavaScript numbers to ensure timestamps are consistently numbers throughout the stack, not strings.

🤖 Generated with [Claude Code](https://claude.ai/code)